### PR TITLE
Avoid expression as label

### DIFF
--- a/vignettes/smer.Rmd
+++ b/vignettes/smer.Rmd
@@ -200,7 +200,7 @@ sme_result$vc_estimate %>%
   geom_boxplot() +
   geom_hline(yintercept = 0.3, color = "grey40", linetype = "dashed") +
   annotate("text", x = 0.7, y =  0.33,
-           label = expression("True " * h^2), color = "black")  +
+           label = "'True ' * h^2", color = "black", parse = TRUE)  +
   xlab("Component") +
   ylab("Variance Component Estimate") +
   theme(legend.position = "none")


### PR DESCRIPTION
Hi there,

We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
The issue was due to a vignette that wouldn't build because an expression was provided as a label. This PR uses a normal character as label.

You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit a fix to CRAN around that time or let us know when ggplot2 should change. Hopefully this will inform you in a timely manner.

Best wishes,
Teun


